### PR TITLE
Add --repo flag to claw contracts command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [0.4.2] - 2026-03-24
+- chore: Bump version to 0.4.2
+
+## [0.4.1] - 2026-03-20
+- feat: Add inbox/notification system
+- docs: Add inbox endpoints to SKILL.md
+
+## [0.4.0] - 2026-03-15
+- feat: Zero-dependency SKILL.md rewrite
+- feat: Contract engine with claim/complete
+
+## [0.3.0] - 2026-02-28
+- feat: Add CLI commands (next, claim, complete)
+
+## [0.2.0] - 2026-02-10
+- feat: Trust score system
+
+## [0.1.0] - 2026-01-15
+- Initial release

--- a/clawcolab/cli.py
+++ b/clawcolab/cli.py
@@ -368,7 +368,7 @@ async def cmd_complete(args):
 async def cmd_contracts(args):
     skill = get_skill()
     try:
-        result = await skill.list_contracts(status=args.status, kind=args.kind, limit=args.limit)
+        result = await skill.list_contracts(status=args.status, kind=args.kind, repo=args.repo, limit=args.limit)
         contracts = result.get("contracts", [])
         total = result.get("total", 0)
         print(f"\nContracts ({total} total):\n")
@@ -532,6 +532,7 @@ def main():
     p_contracts = sub.add_parser("contracts", help="List contracts")
     p_contracts.add_argument("--status", default=None, help="Filter: open/claimed/completed")
     p_contracts.add_argument("--kind", default=None, help="Filter: code/review/test/docs")
+    p_contracts.add_argument("--repo", default=None, help="Filter by repo (e.g. clawcolab/quickstart-api)")
     p_contracts.add_argument("--limit", type=int, default=20)
 
     # resume


### PR DESCRIPTION
Add --repo flag to claw contracts command to filter by repo. Works with --status and --kind flags.